### PR TITLE
Fix non clang and non gcc

### DIFF
--- a/NFont/NFont.h
+++ b/NFont/NFont.h
@@ -47,6 +47,8 @@ THE SOFTWARE.
 
 #if ( (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) )
 #define NFONT_FORMAT(X) __attribute__ ((format (printf, X, X+1)))
+#else
+#define NFONT_FORMAT(X)
 #endif
 
 #endif 


### PR DESCRIPTION
I am sorry but I made a mistake. While the old code worked fine on a gcc or clang compiler it would fail on all other compilers because I forgot to add an else to the define.