### PR TITLE
Update NFont for compatibility with SDL2_ttf v2.24.0+

### DIFF
--- a/NFont/NFont.h
+++ b/NFont/NFont.h
@@ -62,7 +62,7 @@ THE SOFTWARE.
 
 struct FC_Font;
 
-typedef struct _TTF_Font TTF_Font;
+struct TTF_Font;
 
 // Differences between SDL_Renderer and SDL_gpu
 #ifdef NFONT_USE_SDL_GPU


### PR DESCRIPTION
It turns out that SDL2_ttf was updated to match SDL3_ttf, so there is no longer a _TTF_FONT.

Not sure if it is worth adding some conditional logic to allow backwards compatibility with previous versions of SDL2_ttf.